### PR TITLE
Fix urls in markdown are not unescaped.

### DIFF
--- a/core/parser.go
+++ b/core/parser.go
@@ -6,6 +6,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/Wsine/feishu2md/utils"
 	"github.com/chyroc/lark"
 )
 
@@ -131,7 +132,7 @@ func (p *Parser) ParseDocTextRun(tr *lark.DocTextRun) string {
 			postWrite = "`"
 		} else if link := style.Link; link != nil {
 			buf.WriteString("[")
-			postWrite = fmt.Sprintf("](%s)", link.URL)
+			postWrite = fmt.Sprintf("](%s)", utils.UnescapeURL(link.URL))
 		}
 	}
 	buf.WriteString(tr.Text)
@@ -141,7 +142,7 @@ func (p *Parser) ParseDocTextRun(tr *lark.DocTextRun) string {
 
 func (p *Parser) ParseDocDocsLink(l *lark.DocDocsLink) string {
 	buf := new(strings.Builder)
-	buf.WriteString(fmt.Sprintf("[](%s)", l.URL))
+	buf.WriteString(fmt.Sprintf("[](%s)", utils.UnescapeURL(l.URL)))
 	return buf.String()
 }
 
@@ -282,7 +283,7 @@ func (p *Parser) ParseDocxTextElement(e *lark.DocxTextElement) string {
 		buf.WriteString(e.MentionUser.UserID)
 	}
 	if e.MentionDoc != nil {
-		buf.WriteString(fmt.Sprintf("[%s](%s)", e.MentionDoc.Title, e.MentionDoc.URL))
+		buf.WriteString(fmt.Sprintf("[%s](%s)", e.MentionDoc.Title, utils.UnescapeURL(e.MentionDoc.URL)))
 	}
 	if e.Equation != nil {
 		buf.WriteString("%%" + e.Equation.Content + "%%")
@@ -311,7 +312,7 @@ func (p *Parser) ParseDocxTextElementTextRun(tr *lark.DocxTextElementTextRun) st
 			postWrite = "`"
 		} else if link := style.Link; link != nil {
 			buf.WriteString("[")
-			postWrite = fmt.Sprintf("](%s)", link.URL)
+			postWrite = fmt.Sprintf("](%s)", utils.UnescapeURL(link.URL))
 		}
 	}
 	buf.WriteString(tr.Content)

--- a/utils/url.go
+++ b/utils/url.go
@@ -1,0 +1,12 @@
+package utils
+
+import (
+	"net/url"
+)
+
+func UnescapeURL(rawURL string) string {
+	if u, err := url.QueryUnescape(rawURL); err == nil {
+		return u
+	}
+	return rawURL
+}

--- a/utils/url_test.go
+++ b/utils/url_test.go
@@ -1,0 +1,45 @@
+package utils
+
+import (
+	"testing"
+)
+
+func TestUnescapeURL(t *testing.T) {
+	type args struct {
+		rawURL string
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{
+			name: "url unescape success",
+			args: args{
+				rawURL: "https%3A%2F%2Fsspai.com%2Fpost%2F58509",
+			},
+			want: "https://sspai.com/post/58509",
+		},
+		{
+			name: "url unescape failed, keep it",
+			args: args{
+				rawURL: "https$3A$2F$2Fsspai.com$2Fpost$2F58509",
+			},
+			want: "https$3A$2F$2Fsspai.com$2Fpost$2F58509",
+		},
+		{
+			name: "url not need to unescape, keep it",
+			args: args{
+				rawURL: "https://sample.feishu.cn/docs/doccnByZP6puODElAYySJkPIfUb",
+			},
+			want: "https://sample.feishu.cn/docs/doccnByZP6puODElAYySJkPIfUb",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := UnescapeURL(tt.args.rawURL); got != tt.want {
+				t.Errorf("unescapeURL() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
链接没有去掉转义，修了一下，顺便用 gofmt 统一了代码格式。
