### PR TITLE
Add table support

### DIFF
--- a/core/parser.go
+++ b/core/parser.go
@@ -11,6 +11,7 @@ import (
 	"github.com/Wsine/feishu2md/utils"
 	"github.com/chyroc/lark"
 	"github.com/elliotchance/orderedmap/v2"
+	strip "github.com/grokify/html-strip-tags-go"
 	"github.com/olekukonko/tablewriter"
 )
 
@@ -34,7 +35,6 @@ func renderMarkdownTable(data [][]string) string {
 	table.SetAutoWrapText(false)
 	table.SetAutoFormatHeaders(false)
 	table.SetAutoMergeCells(false)
-	table.SetReflowDuringAutoWrap(false)
 	table.SetBorders(tablewriter.Border{Left: true, Top: false, Right: true, Bottom: false})
 	table.SetHeader(data[0])
 	table.AppendBulk(data[1:])
@@ -230,7 +230,8 @@ func (p *Parser) ParseDocTableCell(cell *lark.DocTableCell) string {
 		if content == "" {
 			continue
 		}
-		contents = append(contents, strings.Join(strings.Fields(strings.TrimSpace(content)), " "))
+		content = strings.Join(strings.Fields(strings.TrimSpace(strip.StripTags(content))), " ")
+		contents = append(contents, content)
 	}
 	return strings.Join(contents, " ")
 }
@@ -438,7 +439,8 @@ func (p *Parser) ParseDocxBlockTableCell(blockId string, blockMap *orderedmap.Or
 		if content == "" {
 			continue
 		}
-		contents = append(contents, strings.Join(strings.Fields(strings.TrimSpace(content)), " "))
+		content = strings.Join(strings.Fields(strings.TrimSpace(strip.StripTags(content))), " ")
+		contents = append(contents, content)
 		// remove table cell children block from map
 		blockMap.Delete(block.BlockID)
 	}

--- a/core/parser.go
+++ b/core/parser.go
@@ -2,12 +2,16 @@ package core
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"log"
 	"strconv"
 	"strings"
 
 	"github.com/Wsine/feishu2md/utils"
 	"github.com/chyroc/lark"
+	"github.com/elliotchance/orderedmap/v2"
+	"github.com/olekukonko/tablewriter"
 )
 
 type Parser struct {
@@ -17,6 +21,25 @@ type Parser struct {
 
 func NewParser(ctx context.Context) *Parser {
 	return &Parser{ctx: ctx, ImgTokens: make([]string, 0)}
+}
+
+// =============================================================
+// Parser utils
+// =============================================================
+
+func renderMarkdownTable(data [][]string) string {
+	builder := &strings.Builder{}
+	table := tablewriter.NewWriter(builder)
+	table.SetCenterSeparator("|")
+	table.SetAutoWrapText(false)
+	table.SetAutoFormatHeaders(false)
+	table.SetAutoMergeCells(false)
+	table.SetReflowDuringAutoWrap(false)
+	table.SetBorders(tablewriter.Border{Left: true, Top: false, Right: true, Bottom: false})
+	table.SetHeader(data[0])
+	table.AppendBulk(data[1:])
+	table.Render()
+	return builder.String()
 }
 
 // =============================================================
@@ -93,6 +116,8 @@ func (p *Parser) ParseDocBlock(b *lark.DocBlock) string {
 		return p.ParseDocGallery(b.Gallery)
 	case lark.DocBlockTypeCode:
 		return p.ParseDocCode(b.Code)
+	case lark.DocBlockTypeTable:
+		return p.ParseDocTable(b.Table)
 	default:
 		return ""
 	}
@@ -179,16 +204,74 @@ func (p *Parser) ParseDocCode(c *lark.DocCode) string {
 	return buf.String()
 }
 
+func (p *Parser) ParseDocTableCell(cell *lark.DocTableCell) string {
+	// DocTableCell {
+	//     "columnIndex": int,
+	//     "zoneId": string,
+	//     "body": {object(Body)}
+	// }
+	// convert body(interface{}) to DocBody
+	bytes, err := json.Marshal(cell.Body)
+	if err != nil {
+		log.Printf("failed to marshal %v, err: %s\n", cell.Body, err)
+		return ""
+	}
+	var body lark.DocBody
+	err = json.Unmarshal(bytes, &body)
+	if err != nil {
+		log.Printf("failed to unmarshal '%s', err: %s\n", string(bytes), err)
+		return ""
+	}
+
+	// flatten contents to one line
+	var contents []string
+	for _, block := range body.Blocks {
+		content := p.ParseDocBlock(block)
+		if content == "" {
+			continue
+		}
+		contents = append(contents, strings.Join(strings.Fields(strings.TrimSpace(content)), " "))
+	}
+	return strings.Join(contents, " ")
+}
+
+func (p *Parser) ParseDocTable(t *lark.DocTable) string {
+	// - First row as header
+	// - Ignore cell merging
+	var rows [][]string
+	for _, row := range t.TableRows {
+		var cells []string
+		for _, cell := range row.TableCells {
+			cells = append(cells, p.ParseDocTableCell(cell))
+		}
+		rows = append(rows, cells)
+	}
+
+	buf := new(strings.Builder)
+	buf.WriteString("\n")
+	buf.WriteString(renderMarkdownTable(rows))
+	buf.WriteString("\n")
+	return buf.String()
+}
+
 // =============================================================
 // Parse the new version of document (docx)
 // =============================================================
 
 func (p *Parser) ParseDocxContent(doc *lark.DocxDocument, blocks []*lark.DocxBlock) string {
+	// block map
+	// - Table cell block needs block map to collect children blocks
+	// - ParseDocxContent needs block map to avoid duplicate rendering
+	blockMap := orderedmap.NewOrderedMap[string, *lark.DocxBlock]()
+	for _, block := range blocks {
+		blockMap.Set(block.BlockID, block)
+	}
+
 	buf := new(strings.Builder)
 	// buf.WriteString(p.ParseDocxDocument(doc))
 	// buf.WriteString("\n")
 	for _, v := range blocks {
-		buf.WriteString(p.ParseDocxBlock(v))
+		buf.WriteString(p.ParseDocxBlock(v, blockMap))
 		buf.WriteString("\n")
 	}
 	return buf.String()
@@ -198,7 +281,12 @@ func (p *Parser) ParseDocxDocument(doc *lark.DocxDocument) string {
 	return doc.Title
 }
 
-func (p *Parser) ParseDocxBlock(b *lark.DocxBlock) string {
+func (p *Parser) ParseDocxBlock(b *lark.DocxBlock, blockMap *orderedmap.OrderedMap[string, *lark.DocxBlock]) string {
+	if _, ok := blockMap.Get(b.BlockID); blockMap != nil && !ok {
+		// ignore rendered children block
+		return ""
+	}
+
 	buf := new(strings.Builder)
 	switch b.BlockType {
 	case lark.DocxBlockTypePage:
@@ -259,6 +347,10 @@ func (p *Parser) ParseDocxBlock(b *lark.DocxBlock) string {
 		buf.WriteString(p.ParseDocxBlockText(b.Todo))
 	case lark.DocxBlockTypeImage:
 		buf.WriteString(p.ParseDocxBlockImage(b.Image))
+	case lark.DocxBlockTypeTableCell:
+		buf.WriteString(p.ParseDocxBlockTableCell(b.BlockID, blockMap))
+	case lark.DocxBlockTypeTable:
+		buf.WriteString(p.ParseDocxBlockTable(b.ParentID, b.Table, blockMap))
 	default:
 		return ""
 	}
@@ -331,5 +423,52 @@ func (p *Parser) ParseDocxBlockImage(img *lark.DocxBlockImage) string {
 func (p *Parser) ParseDocxWhatever(body *lark.DocBody) string {
 	buf := new(strings.Builder)
 
+	return buf.String()
+}
+
+func (p *Parser) ParseDocxBlockTableCell(blockId string, blockMap *orderedmap.OrderedMap[string, *lark.DocxBlock]) string {
+	var contents []string
+	for el := blockMap.Front(); el != nil; el = el.Next() {
+		block := el.Value
+		if block.ParentID != blockId {
+			continue
+		}
+
+		content := p.ParseDocxBlock(block, blockMap)
+		if content == "" {
+			continue
+		}
+		contents = append(contents, strings.Join(strings.Fields(strings.TrimSpace(content)), " "))
+		// remove table cell children block from map
+		blockMap.Delete(block.BlockID)
+	}
+	return strings.Join(contents, " ")
+}
+
+func (p *Parser) ParseDocxBlockTable(documentId string, t *lark.DocxBlockTable, blockMap *orderedmap.OrderedMap[string, *lark.DocxBlock]) string {
+	// - First row as header
+	// - Ignore cell merging
+	var rows [][]string
+	for i, blockId := range t.Cells {
+		block, ok := blockMap.Get(blockId)
+		if !ok {
+			log.Printf("got invalid block cell '%s', document: %s\n", blockId, documentId)
+			continue
+		}
+
+		content := p.ParseDocxBlock(block, blockMap)
+		rowIndex := int64(i) / t.Property.ColumnSize
+		if len(rows) < int(rowIndex)+1 {
+			rows = append(rows, []string{})
+		}
+		rows[rowIndex] = append(rows[rowIndex], content)
+		// remove table cell block from map
+		blockMap.Delete(blockId)
+	}
+
+	buf := new(strings.Builder)
+	buf.WriteString("\n")
+	buf.WriteString(renderMarkdownTable(rows))
+	buf.WriteString("\n")
 	return buf.String()
 }

--- a/go.mod
+++ b/go.mod
@@ -1,11 +1,13 @@
 module github.com/Wsine/feishu2md
 
-go 1.17
+go 1.18
 
 require (
 	github.com/88250/lute v1.7.3
 	github.com/chyroc/lark v0.0.97-0.20220706015537-dc21f96c8ebd
+	github.com/elliotchance/orderedmap/v2 v2.2.0
 	github.com/joho/godotenv v1.4.0
+	github.com/olekukonko/tablewriter v0.0.5
 	github.com/urfave/cli/v2 v2.6.0
 )
 
@@ -15,6 +17,8 @@ require (
 	github.com/danwakefield/fnmatch v0.0.0-20160403171240-cbb64ac3d964 // indirect
 	github.com/dlclark/regexp2 v1.4.0 // indirect
 	github.com/gopherjs/gopherjs v0.0.0-20210619142842-05447a1fa367 // indirect
+	github.com/mattn/go-runewidth v0.0.9 // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
-	golang.org/x/text v0.3.6 // indirect
+	golang.org/x/sys v0.0.0-20211019181941-9d821ace8654 // indirect
+	golang.org/x/text v0.3.7 // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/88250/lute v1.7.3
 	github.com/chyroc/lark v0.0.97-0.20220706015537-dc21f96c8ebd
 	github.com/elliotchance/orderedmap/v2 v2.2.0
+	github.com/grokify/html-strip-tags-go v0.0.1
 	github.com/joho/godotenv v1.4.0
 	github.com/olekukonko/tablewriter v0.0.5
 	github.com/urfave/cli/v2 v2.6.0

--- a/go.sum
+++ b/go.sum
@@ -14,7 +14,6 @@ dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7
 github.com/88250/lute v1.7.3 h1:Yuve6dTAZNjWktXpHK14PND4KaBwqVxVi3L+GZa3+HQ=
 github.com/88250/lute v1.7.3/go.mod h1:3CPco034YZBxszJEqBPNgp3a1K+uddq4IegStqBiyTM=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
-github.com/BurntSushi/toml v1.1.0/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbicEuybxQ=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
 github.com/alecthomas/assert v0.0.0-20170929043011-405dbfeb8e38 h1:smF2tmSOzy2Mm+0dGI2AIUHY+w0BUc+4tn40djz7+6U=
@@ -61,6 +60,8 @@ github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZm
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
 github.com/dlclark/regexp2 v1.4.0 h1:F1rxgk7p4uKjwIQxBs9oAXe5CqrXlCduYEJvrF4u93E=
 github.com/dlclark/regexp2 v1.4.0/go.mod h1:2pZnwuY/m+8K6iRw6wQdMtk+rH5tNGR1i55kozfMjCc=
+github.com/elliotchance/orderedmap/v2 v2.2.0 h1:7/2iwO98kYT4XkOjA9mBEIwvi4KpGB4cyHeOFOnj4Vk=
+github.com/elliotchance/orderedmap/v2 v2.2.0/go.mod h1:85lZyVbpGaGvHvnKa7Qhx7zncAdBIBq6u56Hb1PRU5Q=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
@@ -140,6 +141,8 @@ github.com/mattn/go-colorable v0.1.6/go.mod h1:u6P/XSegPjTcexA+o6vUJrdnUu04hMope
 github.com/mattn/go-isatty v0.0.3/go.mod h1:M+lRXTBqGeGNdLjl/ufCoiOlB5xdOkqRJdNxMWT7Zi4=
 github.com/mattn/go-isatty v0.0.12 h1:wuysRhFDzyxgEmMf5xjvJ2M9dZoWAXNNr5LSBS7uHXY=
 github.com/mattn/go-isatty v0.0.12/go.mod h1:cbi8OIDigv2wuxKPP5vlRcQ1OAZbq2CE4Kysco4FUpU=
+github.com/mattn/go-runewidth v0.0.9 h1:Lm995f3rfxdpd6TSmuVCHVb/QhupuXlYr8sCI/QdE+0=
+github.com/mattn/go-runewidth v0.0.9/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/miekg/dns v1.0.14/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=
 github.com/mitchellh/cli v1.0.0/go.mod h1:hNIlj7HEI86fIcpObd7a0FcrxTWetlwJDGcceTlRvqc=
@@ -157,6 +160,8 @@ github.com/neelance/astrewrite v0.0.0-20160511093645-99348263ae86/go.mod h1:kHJE
 github.com/neelance/sourcemap v0.0.0-20200213170602-2833bce08e4c/go.mod h1:Qr6/a/Q4r9LP1IltGz7tA7iOK1WonHEYhu1HRBA7ZiM=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn4U=
+github.com/olekukonko/tablewriter v0.0.5 h1:P2Ga83D34wi1o9J6Wh1mRuqd4mF/x/lgBS7N7AbDhec=
+github.com/olekukonko/tablewriter v0.0.5/go.mod h1:hPp6KlRPjbx+hW8ykQs1w3UBbZlj6HuIJcUGPhkA7kY=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
@@ -296,15 +301,17 @@ golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210119212857-b64e53b001e4/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210403161142-5e06dd20ab57/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20210420205809-ac73e9fd8988 h1:EjgCl+fVlIaPJSori0ikSz3uV0DOHKWOJFpv1sAAhBM=
 golang.org/x/sys v0.0.0-20210420205809-ac73e9fd8988/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20211019181941-9d821ace8654 h1:id054HUawV2/6IGm2IV8KZQjqtwAOo2CYlOToYqa0d0=
+golang.org/x/sys v0.0.0-20211019181941-9d821ace8654/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
-golang.org/x/text v0.3.6 h1:aRYxNxv6iGQlyVaZmk6ZgYEDa+Jg18DxebPSrd6bg1M=
 golang.org/x/text v0.3.6/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
+golang.org/x/text v0.3.7 h1:olpwvP2KacW1ZWvsR7uQhoyTYvKAupfQrRGBFM352Gk=
+golang.org/x/text v0.3.7/go.mod h1:u+2+/6zg+i71rQMx5EYifcz6MCKuco9NR6JIITiCfzQ=
 golang.org/x/time v0.0.0-20181108054448-85acf8d2951c/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/time v0.0.0-20190308202827-9d24e82272b4/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/tools v0.0.0-20180221164845-07fd8470d635/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=

--- a/go.sum
+++ b/go.sum
@@ -96,6 +96,8 @@ github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1/go.mod h1:wJfORR
 github.com/gopherjs/gopherjs v0.0.0-20210619142842-05447a1fa367 h1:7x3XlN7ZRUUHFybdLftf4ZFpi1JYR1w6WL7RPFlWqMM=
 github.com/gopherjs/gopherjs v0.0.0-20210619142842-05447a1fa367/go.mod h1:MtKwTfDNYAP5EtbQSMYjTSqvj1aXJKQRASWq3bwaP+g=
 github.com/gorilla/websocket v1.4.2/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
+github.com/grokify/html-strip-tags-go v0.0.1 h1:0fThFwLbW7P/kOiTBs03FsJSV9RM2M/Q/MOnCQxKMo0=
+github.com/grokify/html-strip-tags-go v0.0.1/go.mod h1:2Su6romC5/1VXOQMaWL2yb618ARB8iVo6/DR99A6d78=
 github.com/grpc-ecosystem/go-grpc-middleware v1.0.0/go.mod h1:FiyG127CGDf3tlThmgyCl78X/SZQqEOJBCDaAfeWzPs=
 github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0/go.mod h1:8NvIoxWQoOIhqOTXgfV/d3M/q6VIi02HzZEHgUlZvzk=
 github.com/grpc-ecosystem/grpc-gateway v1.9.0/go.mod h1:vNeuVxBJEsws4ogUvrchl83t/GYV9WGTSLVdBhOQFDY=


### PR DESCRIPTION
- 添加飞书文档 Table 的支持，支持 `Doc`、`Docx`
- `Docx` 含 `Table` 的页面，所有 `Block` 都会扁平返回，不论父子关系，所以需要增加 `blockMap`来实现父子关系重组，以及防止重复 `Render`
- 尚未添加单元测试，若可接受该 PR，@ 我补充