### PR TITLE
Refine code block

### DIFF
--- a/core/parser.go
+++ b/core/parser.go
@@ -171,7 +171,7 @@ func (p *Parser) ParseDocImageItem(img *lark.DocImageItem) string {
 func (p *Parser) ParseDocCode(c *lark.DocCode) string {
 	buf := new(strings.Builder)
 	buf.WriteString("```")
-	buf.WriteString(c.Language)
+	buf.WriteString(strings.ToLower(c.Language))
 	buf.WriteString("\n")
 	buf.WriteString(p.ParseDocBody(c.Body))
 	buf.WriteString("```")

--- a/core/parser.go
+++ b/core/parser.go
@@ -173,8 +173,8 @@ func (p *Parser) ParseDocCode(c *lark.DocCode) string {
 	buf.WriteString("```")
 	buf.WriteString(strings.ToLower(c.Language))
 	buf.WriteString("\n")
-	buf.WriteString(p.ParseDocBody(c.Body))
-	buf.WriteString("```")
+	buf.WriteString(strings.TrimSpace(p.ParseDocBody(c.Body)))
+	buf.WriteString("\n```")
 	buf.WriteString("\n")
 	return buf.String()
 }
@@ -241,7 +241,7 @@ func (p *Parser) ParseDocxBlock(b *lark.DocxBlock) string {
 		buf.WriteString(p.ParseDocxBlockText(b.Ordered))
 	case lark.DocxBlockTypeCode:
 		buf.WriteString("```\n")
-		buf.WriteString(p.ParseDocxBlockText(b.Code))
+		buf.WriteString(strings.TrimSpace(p.ParseDocxBlockText(b.Code)))
 		buf.WriteString("\n```")
 	case lark.DocxBlockTypeQuote:
 		buf.WriteString("> ")


### PR DESCRIPTION
- `Code Block` 对多余的换行很敏感，需要去掉不必要的换行符
- `Code Block` 的 `Language` 最好小写，因为大多主流 `Markdown` 的解释器都只认小写，比如 https://github.com/facebook/docusaurus
- 尚未添加单元测试，若可接受该 PR，@ 我补充