### PR TITLE
[parser] Refine 'TextRun' rendering

### DIFF
--- a/core/parser.go
+++ b/core/parser.go
@@ -116,14 +116,14 @@ func (p *Parser) ParseDocTextRun(tr *lark.DocTextRun) string {
 	postWrite := ""
 	if style := tr.Style; style != nil {
 		if style.Bold {
-			buf.WriteString("**")
-			postWrite = "**"
+			buf.WriteString("<strong>")
+			postWrite = "</strong>"
 		} else if style.Italic {
-			buf.WriteString("*")
-			postWrite = "*"
+			buf.WriteString("<em>")
+			postWrite = "</em>"
 		} else if style.StrikeThrough {
-			buf.WriteString("~~")
-			postWrite = "~~"
+			buf.WriteString("<del>")
+			postWrite = "</del>"
 		} else if style.Underline {
 			buf.WriteString("<u>")
 			postWrite = "</u>"
@@ -296,14 +296,14 @@ func (p *Parser) ParseDocxTextElementTextRun(tr *lark.DocxTextElementTextRun) st
 	postWrite := ""
 	if style := tr.TextElementStyle; style != nil {
 		if style.Bold {
-			buf.WriteString("**")
-			postWrite = "**"
+			buf.WriteString("<strong>")
+			postWrite = "</strong>"
 		} else if style.Italic {
-			buf.WriteString("*")
-			postWrite = "*"
+			buf.WriteString("<em>")
+			postWrite = "</em>"
 		} else if style.Strikethrough {
-			buf.WriteString("~~")
-			postWrite = "~~"
+			buf.WriteString("<del>")
+			postWrite = "</del>"
 		} else if style.Underline {
 			buf.WriteString("<u>")
 			postWrite = "</u>"


### PR DESCRIPTION
- 使用 '\<strong> | \<em> | \<del>' 等替代 '\*\* | \* | \~\~'
- 因为当存在连续的 `TextRun` 的时候，会出现 `**A****B**`、`**A***B*` 的情况，导致出错
- `DocParagraph. Elements` 是个列表，经常出现这种情况
- 尚未添加单元测试，若可接受该 PR，@ 我补充