### PR TITLE
[parser] Fix 'ParseDocBody' panic

### DIFF
--- a/core/parser.go
+++ b/core/parser.go
@@ -103,6 +103,10 @@ func (p *Parser) ParseDocParagraph(para *lark.DocParagraph, isTitle bool) string
 }
 
 func (p *Parser) ParseDocBody(body *lark.DocBody) string {
+	if body == nil {
+		return ""
+	}
+
 	buf := new(strings.Builder)
 	for _, b := range body.Blocks {
 		buf.WriteString(p.ParseDocBlock(b))


### PR DESCRIPTION
Signed-off-by: weiyang <weiyang.ones@gmail.com>

```
2023/01/09 00:21:01 Capturing document: wikcn5bgJTe9PcA0bWo6KKCLwec
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x2 addr=0x0 pc=0x102283398]

goroutine 1 [running]:
[github.com/Wsine/feishu2md/core.(*Parser).ParseDocBody](http://github.com/Wsine/feishu2md/core.(*Parser).ParseDocBody)(0x14000a0b0f4?, 0x4?)
	/Users/weiyang/Ones/fun/feishu2md/core/parser.go:107 +0x28
[github.com/Wsine/feishu2md/core.(*Parser).ParseDocCode](http://github.com/Wsine/feishu2md/core.(*Parser).ParseDocCode)(0x2e000?, 0x140009d5ec0)
	/Users/weiyang/Ones/fun/feishu2md/core/parser.go:204 +0x1e8
[github.com/Wsine/feishu2md/core.(*Parser).ParseDocBlock](http://github.com/Wsine/feishu2md/core.(*Parser).ParseDocBlock)(0x1027fd3c8?, 0x14003280000?)
	/Users/weiyang/Ones/fun/feishu2md/core/parser.go:121 +0x4c
[github.com/Wsine/feishu2md/core.(*Parser).ParseDocBody](http://github.com/Wsine/feishu2md/core.(*Parser).ParseDocBody)(0x1023b9760?, 0x0?)
	/Users/weiyang/Ones/fun/feishu2md/core/parser.go:108 +0x88
[github.com/Wsine/feishu2md/core.(*Parser).ParseDocContent](http://github.com/Wsine/feishu2md/core.(*Parser).ParseDocContent)(0x140000c4170?, 0x1400011ad10)
	/Users/weiyang/Ones/fun/feishu2md/core/parser.go:53 +0x170
main.handleDocPage(0x140001466c0, {0x140000be0c0?, 0x1400016dd38?}, {0x14000016004, 0x38}, {0x1400016dce0?, 0x0?, 0x0?})
	/Users/weiyang/Ones/fun/xsky-docs-engine/tools/feishu2md/main.go:88 +0x358
main.convertDocDir(0x140001466c0, {0x16ddeee56, 0x1}, {0x16ddeee58, 0x9}, {0x16ddeee67, 0x1b}, {0x14000016004, 0x38})
	/Users/weiyang/Ones/fun/xsky-docs-engine/tools/feishu2md/main.go:169 +0x284
main.handleDocDir(0x14000134280?, {0x16ddeee47?, 0x3?})
	/Users/weiyang/Ones/fun/xsky-docs-engine/tools/feishu2md/main.go:208 +0xbc
main.main()
	/Users/weiyang/Ones/fun/xsky-docs-engine/tools/feishu2md/main.go:259 +0x3b0
exit status 2
```