### PR TITLE
Refine client timeout

### DIFF
--- a/core/client.go
+++ b/core/client.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"time"
 
 	"github.com/Wsine/feishu2md/utils"
 	"github.com/chyroc/lark"
@@ -21,6 +22,7 @@ func NewClient(appID, appSecret, domain string) *Client {
 		larkClient: lark.New(
 			lark.WithAppCredential(appID, appSecret),
 			lark.WithOpenBaseURL("https://open."+domain),
+			lark.WithTimeout(60*time.Second),
 		),
 	}
 }


### PR DESCRIPTION
The default timeout is too short, change it to 60s will be better.
https://github.com/chyroc/lark/blob/843f97f981d72a61f1ccdc7c28ec5f67a09fff26/lark.go#L178