### PR TITLE
增加对LarK URL格式的识别

### DIFF
--- a/cmd/dump.go
+++ b/cmd/dump.go
@@ -17,10 +17,10 @@ func handleDumpCommand(url string) error {
 	config, err := core.ReadConfigFromFile(configPath)
 	utils.CheckErr(err)
 
-	reg := regexp.MustCompile("^https://[a-zA-Z0-9-]+.(feishu.cn|larksuite.com|f.mioffice.cn)/(docx|wiki)/([a-zA-Z0-9]+)")
+	reg := regexp.MustCompile("^https://[a-zA-Z0-9-]+\\.(?:[a-zA-Z]{2,3}\\.)?(feishu\\.cn|larksuite\\.com|f\\.mioffice\\.cn)/(docx|wiki)/([a-zA-Z0-9]+)(?:\\?[^\\s]+)?")
 	matchResult := reg.FindStringSubmatch(url)
-	if matchResult == nil || len(matchResult) != 4 {
-		return errors.Errorf("Invalid feishu/larksuite URL format")
+	if matchResult == nil || len(matchResult) < 4 {
+		return errors.Errorf("Invalid feishu/larksuite "^https://[a-zA-Z0-9-]+\\.(?:[a-zA-Z]{2,3}\\.)?(feishu\\.cn|larksuite\\.com|f\\.mioffice\\.cn)/(docx|wiki)/([a-zA-Z0-9]+)(?:\\?[^\\s]+)?"")
 	}
 
 	domain := matchResult[1]

--- a/cmd/dump.go
+++ b/cmd/dump.go
@@ -20,7 +20,7 @@ func handleDumpCommand(url string) error {
 	reg := regexp.MustCompile("^https://[a-zA-Z0-9-]+\\.(?:[a-zA-Z]{2,3}\\.)?(feishu\\.cn|larksuite\\.com|f\\.mioffice\\.cn)/(docx|wiki)/([a-zA-Z0-9]+)(?:\\?[^\\s]+)?")
 	matchResult := reg.FindStringSubmatch(url)
 	if matchResult == nil || len(matchResult) < 4 {
-		return errors.Errorf("Invalid feishu/larksuite "^https://[a-zA-Z0-9-]+\\.(?:[a-zA-Z]{2,3}\\.)?(feishu\\.cn|larksuite\\.com|f\\.mioffice\\.cn)/(docx|wiki)/([a-zA-Z0-9]+)(?:\\?[^\\s]+)?"")
+		return errors.Errorf("Invalid feishu/larksuite URL format")
 	}
 
 	domain := matchResult[1]


### PR DESCRIPTION
Lark URL的格式形如`https://rfh6a41zvkb.sg.larksuite.com/docx/B8mTdiaH7oLP5XxXiJ3lLNheg6g?from=from_copylink`
中间夹了一个注册邮箱的域名`sg`，最后加了`?from=from_copylink`
上面的分享链接可点开，将在merge后关闭