### PR TITLE
[Feat] 添加批量下载文件夹内全部文档的功能

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,20 @@
       --appId value      Set app id for the OPEN API
       --appSecret value  Set app secret for the OPEN API
       --help, -h         show help (default: false)
+      
+   $ feishu2md dl -h
+   NAME:
+   feishu2md download - Download feishu/larksuite document to markdown file
+
+USAGE:
+   feishu2md download [command options] <url>
+
+OPTIONS:
+   --output value, -o value  Specify the output directory for the markdown files (default: "./")
+   --batch                   batch download all documents inside a folder, where the url is the base folder token (default: false)
+   --dump                    Dump json response of the OPEN API (default: false)
+   --help, -h                show help (default: false)
+     
    ```
 
    **生成配置文件**
@@ -81,7 +95,7 @@
 
    更多的配置选项请手动打开配置文件更改。
 
-   **下载为 Markdown**
+   **下载单个文档为 Markdown**
 
    通过 `feishu2md dl <your feishu docx url>` 直接下载，文档链接可以通过 **分享 > 开启链接分享 > 复制链接** 获得。
 
@@ -93,7 +107,8 @@
 
   **批量下载某文件夹内的全部文档为 Markdown**
 
-  通过`feishu2md batch <your feishu folder token>` 直接下载，文件夹链接可以通过 **分享 > 开启链接分享 > 复制链接** 获得。
+  通过`feishu2md dl --batch <your feishu folder token or url>` 直接下载，文件夹链接可以通过 **分享 > 开启链接分享 > 复制链接** 获得。
+
   示例：
     
   ```bash

--- a/README.md
+++ b/README.md
@@ -90,6 +90,17 @@
    ```bash
    $ feishu2md dl "https://domain.feishu.cn/docx/docxtoken"
    ```
+
+  **批量下载某文件夹内的全部文档为 Markdown**
+
+  通过`feishu2md batch <your feishu folder token>` 直接下载，文件夹链接可以通过 **分享 > 开启链接分享 > 复制链接** 获得。
+  示例：
+    
+  ```bash
+  $ feishu2md batch -o "output_directory" "folder_token"
+  ```
+
+  此功能暂时不支持Docker版本
 </details>
 
 <details>

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ OPTIONS:
   示例：
     
   ```bash
-  $ feishu2md batch -o "output_directory" "folder_token"
+  $ feishu2md dl --batch -o="output_directory" "folder_token or folder_url"  
   ```
 
   此功能暂时不支持Docker版本

--- a/cmd/batchDownload.go
+++ b/cmd/batchDownload.go
@@ -1,0 +1,194 @@
+package main
+
+import (
+	"fmt"
+	"github.com/Wsine/feishu2md/core"
+	"github.com/Wsine/feishu2md/utils"
+	"github.com/pkg/errors"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"sync"
+	"time"
+)
+
+type BatchDownloadOpts struct {
+	baseDir      string
+	outputDir    string
+	larkSpaceURL string
+}
+
+const ApiLimitsPerSec = 5
+
+var batchDownloadOpts = BatchDownloadOpts{}
+
+// Parse the content of a .url file and return the URL
+// The content of a .url file is like this:
+// [InternetShortcut]
+// URL=https://doesnotexists.larksuite.com/docx/doccnL4J5Z6QJ5Z6QJ5Z6QJ5Z6Q
+// Object=doccnL4J5Z6QJ5Z6QJ5Z6QJ5Z6Q
+// The URL is the link to the document
+func parseURL(content string, larkSpaceURL string) (string, error) {
+	lines := strings.Split(content, "\n")
+	for _, line := range lines {
+		if strings.HasPrefix(line, "URL=") {
+			URL := strings.TrimPrefix(line, "URL=")
+			// Use regex to capture the prefix of the URL:
+			// Pattern: https://{USELESS}.com/{URL}
+			pattern := fmt.Sprintf("https://.*?\\.com/(.*)")
+			URL = regexp.MustCompile(pattern).FindStringSubmatch(URL)[1]
+
+			URL = fmt.Sprintf("https://%s/%s", larkSpaceURL, URL)
+			return URL, nil
+		}
+	}
+	return "", errors.New("URL not found in the content")
+}
+
+// Batch download all the documents in the pathMap to the output directory
+// The pathMap is a map of {relativePath, url}
+// This function downloads all the documents using the url to the relativePath in the output directory
+func batchDownload(pathMap map[string]string, outputDir string) error {
+	// Load config
+	configPath, err := core.GetConfigFilePath()
+	utils.CheckErr(err)
+	config, err := core.ReadConfigFromFile(configPath)
+	utils.CheckErr(err)
+
+	var batchErr error = nil
+
+	downloadFunc := func(relPath, url string) {
+		// If the output subdirectory for relPath does not exist, create it
+		outputPath := filepath.Join(outputDir, relPath)
+		subDir := filepath.Dir(outputPath)
+		if _, err := os.Stat(subDir); os.IsNotExist(err) {
+			err := os.MkdirAll(subDir, 0755)
+			if err != nil {
+				fmt.Println("Error creating directory:", err)
+				batchErr = err
+				return
+			}
+		}
+
+		// Download the document
+		err := downloadDocument(url, outputPath, false, config)
+		if err != nil {
+			fmt.Println("Error downloading document:", err)
+			batchErr = err
+			return
+		}
+
+		fmt.Printf("Downloaded markdown file to %s\n", filepath.Join(outputDir, relPath))
+	}
+
+	// API limit is 5 requests per second,
+	// so we use a pool of 5 goroutines added to the pool every second
+	operators := make(chan struct{}, 0)
+	downloadFinished := false
+	// Set a timer to add 5 operators to the pool every 1.5 second (for safety)
+	go func() {
+		for {
+			if downloadFinished {
+				break
+			}
+			for i := 0; i < ApiLimitsPerSec; i++ {
+				operators <- struct{}{}
+			}
+			<-time.After(1500 * time.Millisecond)
+		}
+	}()
+
+	var wg sync.WaitGroup
+	for relPath, url := range pathMap {
+		wg.Add(1)
+		go func(relPath, url string) {
+			<-operators
+			downloadFunc(relPath, url)
+			wg.Done()
+		}(relPath, url)
+	}
+
+	wg.Wait()
+	return batchErr
+}
+
+// `baseDir` is the base directory for the all of the Feishu document direcotry
+// you downloaded
+//
+// In Feishu, you can download a document as a directory, but the directory only
+// contains a bunch of .url files, which are actually the links to the documents
+// This function will fetch all files within the base directory with .url extension
+// and download them all to the output directory with the same hierarchy structure
+//
+// For example, if you have a directory structure like this:
+// baseDir
+// ├── docFolder1
+// │   ├── doc1.url
+// │   └── doc2.url
+// └── docFolder2
+//
+//	├── doc3.url
+//	└── doc4.url
+//
+// `batchDownload` will download all the documents to the output directory with the
+// same structure:
+// outputDir
+// ├── docFolder1
+// │   ├── doc1.md
+// │   └── doc2.md
+// └── docFolder2
+//
+//	├── doc3.md
+//	└── doc4.md
+func handleBatchDownloadCommand(baseDir string, outputDir string, larkSpaceURL string, opts *BatchDownloadOpts) error {
+	// Validate the base directory
+	if _, err := os.Stat(baseDir); os.IsNotExist(err) {
+		return errors.Errorf("Base directory does not exist: %s", baseDir)
+	}
+
+	pathMap := make(map[string]string)
+
+	// Find all files under `baseDir` with .url extension
+	err := filepath.Walk(baseDir,
+		func(path string, info os.FileInfo, err error) error {
+			// DEBUG: print path
+			fmt.Println(path)
+			if err != nil {
+				return err
+			}
+			if filepath.Ext(path) == ".url" {
+				// Read the content of the .url file
+				content, err := os.ReadFile(path)
+				if err != nil {
+					return err
+				}
+				// Parse the URL from the content
+				url, err := parseURL(string(content), larkSpaceURL)
+				if err != nil {
+					return err
+				}
+				// Save pair {relativePath, url} to the map
+				relPath, err := filepath.Rel(baseDir, path)
+				relPath = strings.TrimSuffix(relPath, ".url") + ".md"
+				if err != nil {
+					return err
+				}
+				pathMap[relPath] = url
+			}
+			return nil
+		},
+	)
+
+	if err != nil {
+		return err
+	}
+
+	err = batchDownload(pathMap, outputDir)
+	if err != nil {
+		return err
+	}
+
+	return nil
+
+}

--- a/cmd/batchDownload.go
+++ b/cmd/batchDownload.go
@@ -8,8 +8,6 @@ import (
 	"github.com/pkg/errors"
 	"os"
 	"path/filepath"
-	"regexp"
-	"strings"
 	"sync"
 	"time"
 )
@@ -23,29 +21,6 @@ var downloadFailureList = []string{}
 const ApiLimitsPerSec = 5
 
 var batchDownloadOpts = BatchDownloadOpts{}
-
-// Parse the content of a .url file and return the URL
-// The content of a .url file is like this:
-// [InternetShortcut]
-// URL=https://doesnotexists.larksuite.com/docx/doccnL4J5Z6QJ5Z6QJ5Z6QJ5Z6Q
-// Object=doccnL4J5Z6QJ5Z6QJ5Z6QJ5Z6Q
-// The URL is the link to the document
-func parseURL(content string, larkSpaceURL string) (string, error) {
-	lines := strings.Split(content, "\n")
-	for _, line := range lines {
-		if strings.HasPrefix(line, "URL=") {
-			URL := strings.TrimPrefix(line, "URL=")
-			// Use regex to capture the prefix of the URL:
-			// Pattern: https://{USELESS}.com/{URL}
-			pattern := fmt.Sprintf("https://.*?\\.com/(.*)")
-			URL = regexp.MustCompile(pattern).FindStringSubmatch(URL)[1]
-
-			URL = fmt.Sprintf("https://%s/%s", larkSpaceURL, URL)
-			return URL, nil
-		}
-	}
-	return "", errors.New("URL not found in the content")
-}
 
 func singleDownload(relPath string, url string, outputDir string, config *core.Config) {
 	// If the output subdirectory for relPath does not exist, create it

--- a/cmd/download.go
+++ b/cmd/download.go
@@ -17,6 +17,7 @@ import (
 type DownloadOpts struct {
 	outputDir string
 	dump      bool
+	batch     bool
 }
 
 var downloadOpts = DownloadOpts{}
@@ -120,6 +121,10 @@ func handleDownloadCommand(url string, opts *DownloadOpts) error {
 	utils.CheckErr(err)
 	config, err := core.ReadConfigFromFile(configPath)
 	utils.CheckErr(err)
+
+	if opts.batch {
+		return batchDownloadFolder(opts.outputDir, url, config)
+	}
 
 	return downloadDocument(url, opts.outputDir, opts.dump, config)
 }

--- a/cmd/download.go
+++ b/cmd/download.go
@@ -21,17 +21,14 @@ type DownloadOpts struct {
 
 var downloadOpts = DownloadOpts{}
 
-func handleDownloadCommand(url string, opts *DownloadOpts) error {
+func downloadDocument(url string, outputDir string, dump bool, config *core.Config) error {
 	// Validate the url to download
 	docType, docToken, err := utils.ValidateDownloadURL(url)
-	utils.CheckErr(err)
+	// This might be a sheet or other kind of URL, we don't support downloading it yet so we just skip it
+	if err != nil {
+		return nil
+	}
 	fmt.Println("Captured document token:", docToken)
-
-	// Load config
-	configPath, err := core.GetConfigFilePath()
-	utils.CheckErr(err)
-	config, err := core.ReadConfigFromFile(configPath)
-	utils.CheckErr(err)
 
 	// Create client with context
 	ctx := context.WithValue(context.Background(), "output", config.Output)
@@ -63,7 +60,7 @@ func handleDownloadCommand(url string, opts *DownloadOpts) error {
 	if !config.Output.SkipImgDownload {
 		for _, imgToken := range parser.ImgTokens {
 			localLink, err := client.DownloadImage(
-				ctx, imgToken, filepath.Join(opts.outputDir, config.Output.ImageDir),
+				ctx, imgToken, filepath.Join(outputDir, config.Output.ImageDir),
 			)
 			utils.CheckErr(err)
 			markdown = strings.Replace(markdown, imgToken, localLink, 1)
@@ -77,15 +74,15 @@ func handleDownloadCommand(url string, opts *DownloadOpts) error {
 	result := engine.FormatStr("md", markdown)
 
 	// Handle the output directory and name
-	if _, err := os.Stat(opts.outputDir); os.IsNotExist(err) {
-		if err := os.MkdirAll(opts.outputDir, 0o755); err != nil {
+	if _, err := os.Stat(outputDir); os.IsNotExist(err) {
+		if err := os.MkdirAll(outputDir, 0o755); err != nil {
 			return err
 		}
 	}
 
-	if opts.dump {
+	if dump {
 		jsonName := fmt.Sprintf("%s.json", docToken)
-		outputPath := filepath.Join(opts.outputDir, jsonName)
+		outputPath := filepath.Join(outputDir, jsonName)
 		data := struct {
 			Document *lark.DocxDocument `json:"document"`
 			Blocks   []*lark.DocxBlock  `json:"blocks"`
@@ -106,11 +103,21 @@ func handleDownloadCommand(url string, opts *DownloadOpts) error {
 	if config.Output.TitleAsFilename {
 		mdName = fmt.Sprintf("%s.md", title)
 	}
-	outputPath := filepath.Join(opts.outputDir, mdName)
+	outputPath := filepath.Join(outputDir, mdName)
 	if err = os.WriteFile(outputPath, []byte(result), 0o644); err != nil {
 		return err
 	}
 	fmt.Printf("Downloaded markdown file to %s\n", outputPath)
 
 	return nil
+}
+
+func handleDownloadCommand(url string, opts *DownloadOpts) error {
+	// Load config
+	configPath, err := core.GetConfigFilePath()
+	utils.CheckErr(err)
+	config, err := core.ReadConfigFromFile(configPath)
+	utils.CheckErr(err)
+
+	return downloadDocument(url, opts.outputDir, opts.dump, config)
 }

--- a/cmd/download.go
+++ b/cmd/download.go
@@ -62,7 +62,9 @@ func downloadDocument(url string, outputDir string, dump bool, config *core.Conf
 			localLink, err := client.DownloadImage(
 				ctx, imgToken, filepath.Join(outputDir, config.Output.ImageDir),
 			)
-			utils.CheckErr(err)
+			if utils.CheckErr(err) != nil {
+				return err
+			}
 			markdown = strings.Replace(markdown, imgToken, localLink, 1)
 		}
 	}

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -59,6 +59,12 @@ func main() {
 						Usage:       "Dump json response of the OPEN API",
 						Destination: &downloadOpts.dump,
 					},
+					&cli.BoolFlag{
+						Name:        "batch",
+						Value:       false,
+						Usage:       "batch download all documents inside a folder, where the url is the base folder token",
+						Destination: &downloadOpts.batch,
+					},
 				},
 				ArgsUsage: "<url>",
 				Action: func(ctx *cli.Context) error {
@@ -67,29 +73,6 @@ func main() {
 					} else {
 						url := ctx.Args().First()
 						return handleDownloadCommand(url, &downloadOpts)
-					}
-				},
-			},
-			{
-				Name:    "batch",
-				Aliases: []string{"b"},
-				Usage:   "Download multiple feishu/larksuite documents to markdown files",
-				Flags: []cli.Flag{
-					&cli.StringFlag{
-						Name:        "output",
-						Aliases:     []string{"o"},
-						Value:       "./",
-						Usage:       "Specify the output directory for the markdown files",
-						Destination: &batchDownloadOpts.outputDir,
-					},
-				},
-				ArgsUsage: "<baseFolderToken>",
-				Action: func(ctx *cli.Context) error {
-					if ctx.NArg() == 0 {
-						return cli.Exit("Please specify the base directory for the document urls", 1)
-					} else {
-						baseFolderToken := ctx.Args().First()
-						return handleBatchDownloadCommand(&batchDownloadOpts, &baseFolderToken)
 					}
 				},
 			},

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -70,6 +70,45 @@ func main() {
 					}
 				},
 			},
+			{
+				Name:    "batch",
+				Aliases: []string{"b"},
+				Usage:   "Download multiple feishu/larksuite documents to markdown files",
+				Flags: []cli.Flag{
+					&cli.StringFlag{
+						Name:        "baseDir",
+						Aliases:     []string{"b"},
+						Value:       "",
+						Usage:       "Specify the base directory for the document urls",
+						Destination: &batchDownloadOpts.baseDir,
+					},
+					&cli.StringFlag{
+						Name:        "output",
+						Aliases:     []string{"o"},
+						Value:       "./",
+						Usage:       "Specify the output directory for the markdown files",
+						Destination: &batchDownloadOpts.outputDir,
+					},
+					&cli.StringFlag{
+						Name:        "Lark space URL",
+						Aliases:     []string{"l"},
+						Value:       "xxxxxxxx.larksuite.com",
+						Usage:       "Specify the base URL for your larksuite space without https:// prefix",
+						Destination: &batchDownloadOpts.larkSpaceURL,
+					},
+				},
+				ArgsUsage: "<base directory> <output directory> <lark space URL>",
+				Action: func(ctx *cli.Context) error {
+					if ctx.NArg() == 0 {
+						return cli.Exit("Please specify the base directory for the document urls", 1)
+					} else {
+						baseDir := ctx.Args().Get(0)
+						output := ctx.Args().Get(1)
+						larkSpaceURL := ctx.Args().Get(2)
+						return handleBatchDownloadCommand(baseDir, output, larkSpaceURL, &batchDownloadOpts)
+					}
+				},
+			},
 		},
 	}
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -76,36 +76,20 @@ func main() {
 				Usage:   "Download multiple feishu/larksuite documents to markdown files",
 				Flags: []cli.Flag{
 					&cli.StringFlag{
-						Name:        "baseDir",
-						Aliases:     []string{"b"},
-						Value:       "",
-						Usage:       "Specify the base directory for the document urls",
-						Destination: &batchDownloadOpts.baseDir,
-					},
-					&cli.StringFlag{
 						Name:        "output",
 						Aliases:     []string{"o"},
 						Value:       "./",
 						Usage:       "Specify the output directory for the markdown files",
 						Destination: &batchDownloadOpts.outputDir,
 					},
-					&cli.StringFlag{
-						Name:        "Lark space URL",
-						Aliases:     []string{"l"},
-						Value:       "xxxxxxxx.larksuite.com",
-						Usage:       "Specify the base URL for your larksuite space without https:// prefix",
-						Destination: &batchDownloadOpts.larkSpaceURL,
-					},
 				},
-				ArgsUsage: "<base directory> <output directory> <lark space URL>",
+				ArgsUsage: "<baseFolderToken>",
 				Action: func(ctx *cli.Context) error {
 					if ctx.NArg() == 0 {
 						return cli.Exit("Please specify the base directory for the document urls", 1)
 					} else {
-						baseDir := ctx.Args().Get(0)
-						output := ctx.Args().Get(1)
-						larkSpaceURL := ctx.Args().Get(2)
-						return handleBatchDownloadCommand(baseDir, output, larkSpaceURL, &batchDownloadOpts)
+						baseFolderToken := ctx.Args().First()
+						return handleBatchDownloadCommand(&batchDownloadOpts, &baseFolderToken)
 					}
 				},
 			},

--- a/core/client.go
+++ b/core/client.go
@@ -156,7 +156,7 @@ type Pair struct {
 	url  string
 }
 
-func (c *Client) GetDriveStructure(ctx context.Context, baseFolderToken *string) (map[string]string, error) {
+func (c *Client) GetDriveStructure(ctx context.Context, baseFolderToken string) (map[string]string, error) {
 	pairChannel := make(chan Pair)
 	structure := map[string]string{}
 	wg := sync.WaitGroup{}
@@ -166,7 +166,7 @@ func (c *Client) GetDriveStructure(ctx context.Context, baseFolderToken *string)
 		}
 	}()
 	wg.Add(1)
-	err := c.GetDriveStructureRecursion(ctx, *baseFolderToken, ".", pairChannel, &wg)
+	err := c.GetDriveStructureRecursion(ctx, baseFolderToken, ".", pairChannel, &wg)
 
 	wg.Wait()
 

--- a/core/client_test.go
+++ b/core/client_test.go
@@ -93,3 +93,16 @@ func TestGetWikiNodeInfo(t *testing.T) {
 		t.Errorf("Error: node type incorrect")
 	}
 }
+
+func TestGetDriveStructure(t *testing.T) {
+	appID, appSecret := getIdAndSecretFromEnv(t)
+	c := core.NewClient(appID, appSecret)
+	baseFolderToken := "VknBfQ1pdla6AddwgkUuHT1ks7c"
+	structure, err := c.GetDriveStructure(context.Background(), &baseFolderToken)
+	if err != nil {
+		t.Error(err)
+	}
+	for path, url := range structure {
+		fmt.Printf("%s: %s\n", path, url)
+	}
+}

--- a/utils/common.go
+++ b/utils/common.go
@@ -7,7 +7,9 @@ import (
 	"strings"
 )
 
-func CheckErr(e error) {
+var StopWhenErr = true
+
+func CheckErr(e error) error {
 	if e != nil {
 		fmt.Fprintln(os.Stderr, e)
 		fmt.Fprintf(
@@ -16,8 +18,11 @@ func CheckErr(e error) {
 			strings.Repeat("=", 20),
 			"Report the following if it is a bug",
 		)
-		panic(e)
+		if StopWhenErr {
+			panic(e)
+		}
 	}
+	return e
 }
 
 func PrettyPrint(i interface{}) string {


### PR DESCRIPTION
示例：
```
feishu2md batch -o "output_directory" "folder_token"
```
用来下载token名为folder_token的飞书文件夹下的所有文档，并且会以相同目录结构保存在output_directory中

注意：API限流为每秒最多调用5次，文件较多时下载速度会较为缓慢

TODO:
- 貌似无法从飞书空间根目录开始下载