### PR TITLE
新增高亮块和表格换行处理功能

### DIFF
--- a/core/client.go
+++ b/core/client.go
@@ -22,7 +22,7 @@ func NewClient(appID, appSecret string) *Client {
 		larkClient: lark.New(
 			lark.WithAppCredential(appID, appSecret),
 			lark.WithTimeout(60*time.Second),
-			lark.WithTimeout(60*time.Second),
+			lark.WithApiMiddleware(lark_rate_limiter.Wait(5, 5)),
 		),
 	}
 }

--- a/core/client.go
+++ b/core/client.go
@@ -10,19 +10,18 @@ import (
 	"time"
 
 	"github.com/chyroc/lark"
-	"github.com/chyroc/lark_rate_limiter"
 )
 
 type Client struct {
 	larkClient *lark.Lark
 }
 
-func NewClient(appID, appSecret string) *Client {
+func NewClient(appID, appSecret string, domain string) *Client {
 	return &Client{
 		larkClient: lark.New(
 			lark.WithAppCredential(appID, appSecret),
+			lark.WithOpenBaseURL("https://open."+domain),
 			lark.WithTimeout(60*time.Second),
-			lark.WithApiMiddleware(lark_rate_limiter.Wait(5, 5)),
 		),
 	}
 }
@@ -66,10 +65,22 @@ func (c *Client) DownloadImageRaw(ctx context.Context, imgToken, imgDir string) 
 	return filename, buf.Bytes(), nil
 }
 
-func (c *Client) GetDocxContent(ctx context.Context, docToken string) (*lark.DocxDocument, []*lark.DocxBlock, error) {
-	resp, _, err := c.larkClient.Drive.GetDocxDocument(ctx, &lark.GetDocxDocumentReq{
-		DocumentID: docToken,
-	})
+func (c *Client) GetDocxContent(ctx context.Context, docToken string, UserAccessToken string) (*lark.DocxDocument, []*lark.DocxBlock, error) {
+	var resp *lark.GetDocxDocumentResp
+	var err error
+	 // 判断 UserAccessToken 是否为空
+    if UserAccessToken != "" {
+        // 调用 GetDocxDocument 方法并传递选项
+        resp, _, err = c.larkClient.Drive.GetDocxDocument(ctx, &lark.GetDocxDocumentReq{
+            DocumentID: docToken,
+        }, lark.WithUserAccessToken(UserAccessToken))
+    } else {
+        // 调用 GetDocxDocument 方法不传递选项
+        resp, _, err = c.larkClient.Drive.GetDocxDocument(ctx, &lark.GetDocxDocumentReq{
+            DocumentID: docToken,
+        })
+    }
+
 	if err != nil {
 		return nil, nil, err
 	}
@@ -81,10 +92,23 @@ func (c *Client) GetDocxContent(ctx context.Context, docToken string) (*lark.Doc
 	var blocks []*lark.DocxBlock
 	var pageToken *string
 	for {
-		resp2, _, err := c.larkClient.Drive.GetDocxBlockListOfDocument(ctx, &lark.GetDocxBlockListOfDocumentReq{
-			DocumentID: docx.DocumentID,
-			PageToken:  pageToken,
-		})
+		//resp2, _, err := c.larkClient.Drive.GetDocxBlockListOfDocument(ctx, &lark.GetDocxBlockListOfDocumentReq{
+		//	DocumentID: docx.DocumentID,
+		//	PageToken:  pageToken,
+		//})
+		var resp2 *lark.GetDocxBlockListOfDocumentResp
+		var err error
+		if UserAccessToken != "" {
+			resp2, _, err = c.larkClient.Drive.GetDocxBlockListOfDocument(ctx, &lark.GetDocxBlockListOfDocumentReq{
+				DocumentID: docx.DocumentID,
+				PageToken:  pageToken,
+			}, lark.WithUserAccessToken(UserAccessToken))
+		} else {
+			resp2, _, err = c.larkClient.Drive.GetDocxBlockListOfDocument(ctx, &lark.GetDocxBlockListOfDocumentReq{
+        		DocumentID: docx.DocumentID,
+       			 PageToken:  pageToken,
+    		})
+		}
 		if err != nil {
 			return docx, nil, err
 		}

--- a/core/parser.go
+++ b/core/parser.go
@@ -1,4 +1,3 @@
-
 package core
 
 import (

--- a/core/parser.go
+++ b/core/parser.go
@@ -1,3 +1,4 @@
+
 package core
 
 import (
@@ -133,6 +134,8 @@ func (p *Parser) ParseDocxBlock(b *lark.DocxBlock, indentLevel int) string {
 		buf.WriteString(p.ParseDocxBlockPage(b))
 	case lark.DocxBlockTypeText:
 		buf.WriteString(p.ParseDocxBlockText(b.Text))
+	case lark.DocxBlockTypeCallout:
+		buf.WriteString(p.ParseDocxBlockCallout(b))
 	case lark.DocxBlockTypeHeading1:
 		buf.WriteString(p.ParseDocxBlockHeading(b, 1))
 	case lark.DocxBlockTypeHeading2:
@@ -217,6 +220,18 @@ func (p *Parser) ParseDocxBlockText(b *lark.DocxBlockText) string {
 	return buf.String()
 }
 
+func (p *Parser) ParseDocxBlockCallout(b *lark.DocxBlock) string {
+	buf := new(strings.Builder)
+
+	buf.WriteString(">[!TIP] \n")
+
+	for _, childId := range b.Children {
+		childBlock := p.blockMap[childId]
+		buf.WriteString(p.ParseDocxBlock(childBlock, 0))
+	}
+
+	return buf.String()
+}
 func (p *Parser) ParseDocxTextElement(e *lark.DocxTextElement, inline bool) string {
 	buf := new(strings.Builder)
 	if e.TextRun != nil {
@@ -364,7 +379,7 @@ func (p *Parser) ParseDocxBlockTableCell(b *lark.DocxBlock) string {
 	for _, child := range b.Children {
 		block := p.blockMap[child]
 		content := p.ParseDocxBlock(block, 0)
-		buf.WriteString(content)
+		buf.WriteString(content + "<br/>")
 	}
 
 	return buf.String()


### PR DESCRIPTION
1.对飞书文档中的高亮块类型，使用markdown中的 提示效果来实现高亮
2.项目中飞书中的表格转换为markdown后无法换行，通过<br>来实现换行效果