### PR TITLE
feat: Support embedded spreadsheets and fix quote block formatting

### DIFF
--- a/cmd/download.go
+++ b/cmd/download.go
@@ -264,7 +264,7 @@ func downloadWiki(ctx context.Context, client *core.Client, url string) error {
 					<-semaphore
 				}()
 			}
-			
+
 			// 然后递归处理子节点
 			if n.HasChild {
 				_folderPath := filepath.Join(folderPath, n.Title)

--- a/cmd/download.go
+++ b/cmd/download.go
@@ -53,7 +53,7 @@ func downloadDocument(ctx context.Context, client *core.Client, url string, opts
 	docx, blocks, err := client.GetDocxContent(ctx, docToken)
 	utils.CheckErr(err)
 
-	parser := core.NewParser(dlConfig.Output)
+	parser := core.NewParser(dlConfig.Output, client)
 
 	title := docx.Title
 	markdown := parser.ParseDocxContent(docx, blocks)

--- a/cmd/download.go
+++ b/cmd/download.go
@@ -34,6 +34,7 @@ func downloadDocument(ctx context.Context, client *core.Client, url string, opts
 	fmt.Println("Captured document token:", docToken)
 
 	// for a wiki page, we need to renew docType and docToken first
+	var nodeTitle string
 	if docType == "wiki" {
 		node, err := client.GetWikiNodeInfo(ctx, docToken)
 		if err != nil {
@@ -42,6 +43,7 @@ func downloadDocument(ctx context.Context, client *core.Client, url string, opts
 		utils.CheckErr(err)
 		docType = node.ObjType
 		docToken = node.ObjToken
+		nodeTitle = node.Title
 	}
 	if docType == "docs" {
 		return errors.Errorf(
@@ -49,11 +51,18 @@ func downloadDocument(ctx context.Context, client *core.Client, url string, opts
 				`Please refer to the Readme/Release for v1_support.`)
 	}
 
+	// Handle non-docx file types (mindnote, file, sheet, bitable)
+	if docType != "docx" {
+		return downloadFile(ctx, client, docToken, nodeTitle, opts.outputDir, docType)
+	}
+
 	// Process the download
 	docx, blocks, err := client.GetDocxContent(ctx, docToken)
 	utils.CheckErr(err)
 
 	parser := core.NewParser(dlConfig.Output, client)
+	parser.SetContext(ctx)
+	parser.SetOutputDir(filepath.Join(opts.outputDir, dlConfig.Output.ImageDir))
 
 	title := docx.Title
 	markdown := parser.ParseDocxContent(docx, blocks)
@@ -170,9 +179,28 @@ func downloadDocuments(ctx context.Context, client *core.Client, url string) err
 }
 
 func downloadWiki(ctx context.Context, client *core.Client, url string) error {
-	prefixURL, spaceID, err := utils.ValidateWikiURL(url)
+	prefixURL, wikiToken, err := utils.ValidateWikiURL(url)
 	if err != nil {
 		return err
+	}
+
+	var spaceID string
+	// Check if the token is a space_id (from /wiki/settings/ URL) or a node_token (from /wiki/ URL)
+	// Try to get wiki space info first - if it works, it's a space_id
+	_, err = client.GetWikiName(ctx, wikiToken)
+	if err == nil {
+		// It's a valid space_id
+		spaceID = wikiToken
+	} else {
+		// It's likely a node_token, get node info to extract space_id
+		node, err := client.GetWikiNodeInfo(ctx, wikiToken)
+		if err != nil {
+			return fmt.Errorf("failed to get wiki node info: %v", err)
+		}
+		if node.SpaceID == "" {
+			return fmt.Errorf("node does not have a space_id")
+		}
+		spaceID = node.SpaceID
 	}
 
 	folderPath, err := client.GetWikiName(ctx, spaceID)
@@ -182,6 +210,8 @@ func downloadWiki(ctx context.Context, client *core.Client, url string) error {
 	if folderPath == "" {
 		return fmt.Errorf("failed to GetWikiName")
 	}
+	// Combine with output directory
+	folderPath = filepath.Join(dlOpts.outputDir, folderPath)
 
 	errChan := make(chan error)
 
@@ -205,13 +235,8 @@ func downloadWiki(ctx context.Context, client *core.Client, url string) error {
 			return err
 		}
 		for _, n := range nodes {
-			if n.HasChild {
-				_folderPath := filepath.Join(folderPath, n.Title)
-				if err := downloadWikiNode(ctx, client,
-					spaceID, _folderPath, &n.NodeToken); err != nil {
-					return err
-				}
-			}
+			// 先处理节点本身的文档内容（如果有的话）
+			// Handle different object types
 			if n.ObjType == "docx" {
 				opts := DownloadOpts{outputDir: folderPath, dump: dlOpts.dump, batch: false}
 				wg.Add(1)
@@ -223,7 +248,30 @@ func downloadWiki(ctx context.Context, client *core.Client, url string) error {
 					wg.Done()
 					<-semaphore
 				}(prefixURL + "/wiki/" + n.NodeToken)
-				// downloadDocument(ctx, client, prefixURL+"/wiki/"+n.NodeToken, &opts)
+			} else if n.ObjType == "mindnote" || n.ObjType == "file" || n.ObjType == "sheet" || n.ObjType == "bitable" {
+				// Download other file types (mindnote, video, sheet, bitable, etc.)
+				// Capture variables for goroutine
+				objToken := n.ObjToken
+				title := n.Title
+				objType := n.ObjType
+				wg.Add(1)
+				semaphore <- struct{}{}
+				go func() {
+					if err := downloadFile(ctx, client, objToken, title, folderPath, objType); err != nil {
+						errChan <- err
+					}
+					wg.Done()
+					<-semaphore
+				}()
+			}
+			
+			// 然后递归处理子节点
+			if n.HasChild {
+				_folderPath := filepath.Join(folderPath, n.Title)
+				if err := downloadWikiNode(ctx, client,
+					spaceID, _folderPath, &n.NodeToken); err != nil {
+					return err
+				}
 			}
 		}
 		return nil
@@ -271,4 +319,14 @@ func handleDownloadCommand(url string) error {
 	}
 
 	return downloadDocument(ctx, client, url, &dlOpts)
+}
+
+func downloadFile(ctx context.Context, client *core.Client, nodeToken, title, outputDir, objType string) error {
+	// Download the file using the objToken
+	filePath, err := client.DownloadFile(ctx, nodeToken, outputDir, objType, title)
+	if err != nil {
+		return fmt.Errorf("failed to download file %s: %v", title, err)
+	}
+	fmt.Printf("Downloaded file to %s\n", filePath)
+	return nil
 }

--- a/core/client.go
+++ b/core/client.go
@@ -261,7 +261,8 @@ func (c *Client) GetSheetContent(ctx context.Context, sheetToken string) ([][]st
 		for j, cell := range row {
 			// 根据单元格类型提取值
 			if cell.String != nil {
-				result[i][j] = *cell.String
+				// 将换行符转换为 <br> 标签，以便在 markdown 表格中正确显示
+				result[i][j] = strings.ReplaceAll(*cell.String, "\n", "<br>")
 			} else if cell.Int != nil {
 				result[i][j] = fmt.Sprintf("%d", *cell.Int)
 			} else if cell.Float != nil {

--- a/core/parser.go
+++ b/core/parser.go
@@ -14,7 +14,7 @@ import (
 )
 
 type Parser struct {
-	client     *Client
+	client      *Client
 	useHTMLTags bool
 	ImgTokens   []string
 	blockMap    map[string]*lark.DocxBlock
@@ -24,7 +24,7 @@ type Parser struct {
 
 func NewParser(config OutputConfig, client *Client) *Parser {
 	return &Parser{
-		client:     client,
+		client:      client,
 		useHTMLTags: config.UseHTMLTags,
 		ImgTokens:   make([]string, 0),
 		blockMap:    make(map[string]*lark.DocxBlock),
@@ -359,7 +359,7 @@ func (p *Parser) ParseDocxBlockImage(img *lark.DocxBlockImage) string {
 
 func (p *Parser) ParseDocxBlockFile(file *lark.DocxBlockFile) string {
 	buf := new(strings.Builder)
-	
+
 	// Get file extension to determine file type
 	var fileType string
 	var fileName string
@@ -368,27 +368,27 @@ func (p *Parser) ParseDocxBlockFile(file *lark.DocxBlockFile) string {
 	} else {
 		fileName = file.Token
 	}
-	
+
 	// Determine file type based on name or token
-	if strings.Contains(strings.ToLower(fileName), ".mp4") || 
-	   strings.Contains(strings.ToLower(fileName), ".mov") ||
-	   strings.Contains(strings.ToLower(fileName), ".avi") ||
-	   strings.Contains(strings.ToLower(fileName), ".mkv") {
+	if strings.Contains(strings.ToLower(fileName), ".mp4") ||
+		strings.Contains(strings.ToLower(fileName), ".mov") ||
+		strings.Contains(strings.ToLower(fileName), ".avi") ||
+		strings.Contains(strings.ToLower(fileName), ".mkv") {
 		fileType = "视频"
 	} else if strings.Contains(strings.ToLower(fileName), ".pdf") {
 		fileType = "PDF"
 	} else if strings.Contains(strings.ToLower(fileName), ".doc") ||
-	   strings.Contains(strings.ToLower(fileName), ".docx") {
+		strings.Contains(strings.ToLower(fileName), ".docx") {
 		fileType = "Word文档"
 	} else if strings.Contains(strings.ToLower(fileName), ".xls") ||
-	   strings.Contains(strings.ToLower(fileName), ".xlsx") {
+		strings.Contains(strings.ToLower(fileName), ".xlsx") {
 		fileType = "Excel表格"
 	} else {
 		fileType = "文件"
 	}
-	
+
 	buf.WriteString(fmt.Sprintf("\n**附件**: %s (%s)\n\n", fileName, fileType))
-	
+
 	// Try to download the file if context and outputDir are set
 	// For file blocks inside documents, we should use DownloadDriveMedia
 	if p.ctx != nil && p.outputDir != "" && p.client != nil {
@@ -396,14 +396,14 @@ func (p *Parser) ParseDocxBlockFile(file *lark.DocxBlockFile) string {
 		resp, _, err := p.client.larkClient.Drive.DownloadDriveMedia(p.ctx, &lark.DownloadDriveMediaReq{
 			FileToken: file.Token,
 		})
-		
+
 		if err == nil && resp != nil {
 			// File downloaded successfully
 			downloadedFilename := resp.Filename
 			if downloadedFilename == "" {
 				downloadedFilename = file.Token
 			}
-			
+
 			filePath := filepath.Join(p.outputDir, downloadedFilename)
 			err := os.MkdirAll(filepath.Dir(filePath), 0o755)
 			if err == nil {
@@ -419,10 +419,10 @@ func (p *Parser) ParseDocxBlockFile(file *lark.DocxBlockFile) string {
 		}
 		// Download failed, fall through to placeholder
 	}
-	
+
 	buf.WriteString(fmt.Sprintf("**文件Token**: `%s`\n\n", file.Token))
 	buf.WriteString(fmt.Sprintf("**提示**: 这是一个%s附件，请访问飞书查看原始文件。\n\n", fileType))
-	
+
 	return buf.String()
 }
 

--- a/core/parser.go
+++ b/core/parser.go
@@ -3,6 +3,8 @@ package core
 import (
 	"context"
 	"fmt"
+	"os"
+	"path/filepath"
 	"reflect"
 	"strings"
 
@@ -16,6 +18,8 @@ type Parser struct {
 	useHTMLTags bool
 	ImgTokens   []string
 	blockMap    map[string]*lark.DocxBlock
+	ctx         context.Context
+	outputDir   string
 }
 
 func NewParser(config OutputConfig, client *Client) *Parser {
@@ -24,7 +28,19 @@ func NewParser(config OutputConfig, client *Client) *Parser {
 		useHTMLTags: config.UseHTMLTags,
 		ImgTokens:   make([]string, 0),
 		blockMap:    make(map[string]*lark.DocxBlock),
+		ctx:         context.Background(),
+		outputDir:   "",
 	}
+}
+
+// SetContext sets the context for the parser
+func (p *Parser) SetContext(ctx context.Context) {
+	p.ctx = ctx
+}
+
+// SetOutputDir sets the output directory for the parser
+func (p *Parser) SetOutputDir(outputDir string) {
+	p.outputDir = outputDir
 }
 
 // =============================================================
@@ -131,6 +147,7 @@ func (p *Parser) ParseDocxContent(doc *lark.DocxDocument, blocks []*lark.DocxBlo
 func (p *Parser) ParseDocxBlock(b *lark.DocxBlock, indentLevel int) string {
 	buf := new(strings.Builder)
 	buf.WriteString(strings.Repeat("\t", indentLevel))
+
 	switch b.BlockType {
 	case lark.DocxBlockTypePage:
 		buf.WriteString(p.ParseDocxBlockPage(b))
@@ -182,6 +199,14 @@ func (p *Parser) ParseDocxBlock(b *lark.DocxBlock, indentLevel int) string {
 		buf.WriteString("---\n")
 	case lark.DocxBlockTypeImage:
 		buf.WriteString(p.ParseDocxBlockImage(b.Image))
+	case lark.DocxBlockTypeFile:
+		buf.WriteString(p.ParseDocxBlockFile(b.File))
+	case lark.DocxBlockTypeBitable:
+		buf.WriteString(p.ParseDocxBlockBitable(b.Bitable))
+	case lark.DocxBlockTypeDiagram:
+		buf.WriteString(p.ParseDocxBlockDiagram(b.Diagram))
+	case lark.DocxBlockTypeIframe:
+		buf.WriteString(p.ParseDocxBlockIframe(b.Iframe))
 	case lark.DocxBlockTypeTableCell:
 		buf.WriteString(p.ParseDocxBlockTableCell(b))
 	case lark.DocxBlockTypeTable:
@@ -193,6 +218,11 @@ func (p *Parser) ParseDocxBlock(b *lark.DocxBlock, indentLevel int) string {
 	case lark.DocxBlockTypeGrid:
 		buf.WriteString(p.ParseDocxBlockGrid(b, indentLevel))
 	default:
+		// 对于不支持的 block type，仍然处理其 children
+		for _, childId := range b.Children {
+			childBlock := p.blockMap[childId]
+			buf.WriteString(p.ParseDocxBlock(childBlock, indentLevel))
+		}
 	}
 	return buf.String()
 }
@@ -324,6 +354,75 @@ func (p *Parser) ParseDocxBlockImage(img *lark.DocxBlockImage) string {
 	buf.WriteString(fmt.Sprintf("![](%s)", img.Token))
 	buf.WriteString("\n")
 	p.ImgTokens = append(p.ImgTokens, img.Token)
+	return buf.String()
+}
+
+func (p *Parser) ParseDocxBlockFile(file *lark.DocxBlockFile) string {
+	buf := new(strings.Builder)
+	
+	// Get file extension to determine file type
+	var fileType string
+	var fileName string
+	if file.Name != "" {
+		fileName = file.Name
+	} else {
+		fileName = file.Token
+	}
+	
+	// Determine file type based on name or token
+	if strings.Contains(strings.ToLower(fileName), ".mp4") || 
+	   strings.Contains(strings.ToLower(fileName), ".mov") ||
+	   strings.Contains(strings.ToLower(fileName), ".avi") ||
+	   strings.Contains(strings.ToLower(fileName), ".mkv") {
+		fileType = "视频"
+	} else if strings.Contains(strings.ToLower(fileName), ".pdf") {
+		fileType = "PDF"
+	} else if strings.Contains(strings.ToLower(fileName), ".doc") ||
+	   strings.Contains(strings.ToLower(fileName), ".docx") {
+		fileType = "Word文档"
+	} else if strings.Contains(strings.ToLower(fileName), ".xls") ||
+	   strings.Contains(strings.ToLower(fileName), ".xlsx") {
+		fileType = "Excel表格"
+	} else {
+		fileType = "文件"
+	}
+	
+	buf.WriteString(fmt.Sprintf("\n**附件**: %s (%s)\n\n", fileName, fileType))
+	
+	// Try to download the file if context and outputDir are set
+	// For file blocks inside documents, we should use DownloadDriveMedia
+	if p.ctx != nil && p.outputDir != "" && p.client != nil {
+		// Use DownloadDriveMedia for file blocks inside documents
+		resp, _, err := p.client.larkClient.Drive.DownloadDriveMedia(p.ctx, &lark.DownloadDriveMediaReq{
+			FileToken: file.Token,
+		})
+		
+		if err == nil && resp != nil {
+			// File downloaded successfully
+			downloadedFilename := resp.Filename
+			if downloadedFilename == "" {
+				downloadedFilename = file.Token
+			}
+			
+			filePath := filepath.Join(p.outputDir, downloadedFilename)
+			err := os.MkdirAll(filepath.Dir(filePath), 0o755)
+			if err == nil {
+				file, err := os.OpenFile(filePath, os.O_CREATE|os.O_WRONLY, 0o666)
+				if err == nil {
+					written, err := file.ReadFrom(resp.File)
+					if err == nil {
+						buf.WriteString(fmt.Sprintf("**下载成功**: 文件已保存到 `%s` (大小: %d bytes)\n\n", filePath, written))
+						return buf.String()
+					}
+				}
+			}
+		}
+		// Download failed, fall through to placeholder
+	}
+	
+	buf.WriteString(fmt.Sprintf("**文件Token**: `%s`\n\n", file.Token))
+	buf.WriteString(fmt.Sprintf("**提示**: 这是一个%s附件，请访问飞书查看原始文件。\n\n", fileType))
+	
 	return buf.String()
 }
 
@@ -590,6 +689,148 @@ func (p *Parser) ParseDocxBlockSheet(s *lark.DocxBlockSheet) string {
 		buf.WriteString("\n")
 	}
 	buf.WriteString("\n")
+
+	return buf.String()
+}
+
+// ParseDocxBlockBitable 解析多维表格块
+func (p *Parser) ParseDocxBlockBitable(bitable *lark.DocxBlockBitable) string {
+	buf := new(strings.Builder)
+
+	// 如果没有 client 或 token，则返回占位符
+	if p.client == nil || bitable.Token == "" {
+		buf.WriteString("\n\n")
+		buf.WriteString("> **📊 多维表格**\n")
+		buf.WriteString(">\n")
+		if bitable.Token != "" {
+			buf.WriteString(fmt.Sprintf("> Token: `%s`\n", bitable.Token))
+		}
+		buf.WriteString(">\n")
+		buf.WriteString("> *注：无法获取多维表格内容（缺少 client 或 token）*\n")
+		buf.WriteString("\n\n")
+		return buf.String()
+	}
+
+	// 尝试获取多维表格的实际内容
+	ctx := context.Background()
+	values, err := p.client.GetBitableContent(ctx, bitable.Token)
+	if err != nil {
+		// 如果获取失败，返回占位符
+		buf.WriteString("\n\n")
+		buf.WriteString("> **📊 多维表格**\n")
+		buf.WriteString(">\n")
+		if bitable.Token != "" {
+			buf.WriteString(fmt.Sprintf("> Token: `%s`\n", bitable.Token))
+		}
+		buf.WriteString(">\n")
+		buf.WriteString(fmt.Sprintf("> *获取多维表格内容失败: %v*\n", err))
+		buf.WriteString("\n\n")
+		return buf.String()
+	}
+
+	// 将多维表格数据转换为 markdown 表格
+	if len(values) == 0 {
+		buf.WriteString("\n\n")
+		buf.WriteString("> **📊 多维表格**\n")
+		buf.WriteString(">\n")
+		if bitable.Token != "" {
+			buf.WriteString(fmt.Sprintf("> Token: `%s`\n", bitable.Token))
+		}
+		buf.WriteString(">\n")
+		buf.WriteString("> *多维表格为空*\n")
+		buf.WriteString("\n\n")
+		return buf.String()
+	}
+
+	// 生成 markdown 表格
+	buf.WriteString("\n\n")
+	// 表头
+	buf.WriteString("|")
+	for _, cell := range values[0] {
+		buf.WriteString(" " + cell + " |")
+	}
+	buf.WriteString("\n")
+	// 分隔线
+	buf.WriteString("|")
+	for range values[0] {
+		buf.WriteString(" --- |")
+	}
+	buf.WriteString("\n")
+	// 数据行
+	for i := 1; i < len(values); i++ {
+		buf.WriteString("|")
+		for _, cell := range values[i] {
+			buf.WriteString(" " + cell + " |")
+		}
+		buf.WriteString("\n")
+	}
+	buf.WriteString("\n")
+
+	return buf.String()
+}
+
+// ParseDocxBlockDiagram 解析流程图/UML块
+func (p *Parser) ParseDocxBlockDiagram(diagram *lark.DocxBlockDiagram) string {
+	buf := new(strings.Builder)
+
+	diagramType := "流程图"
+	if diagram.DiagramType == 2 {
+		diagramType = "UML图"
+	}
+
+	buf.WriteString("\n\n")
+	buf.WriteString(fmt.Sprintf("**📈 %s**\n\n", diagramType))
+	buf.WriteString("> *注：流程图/UML图无法直接转换为 Markdown，建议导出为图片或使用 Mermaid 语法*\n")
+	buf.WriteString("\n\n")
+
+	return buf.String()
+}
+
+// ParseDocxBlockIframe 解析内嵌块
+func (p *Parser) ParseDocxBlockIframe(iframe *lark.DocxBlockIframe) string {
+	buf := new(strings.Builder)
+
+	buf.WriteString("\n\n")
+	buf.WriteString("**🔗 嵌入内容**\n\n")
+
+	if iframe.Component != nil {
+		// 获取 iframe 类型名称
+		typeNames := map[int]string{
+			1:  "哔哩哔哩",
+			2:  "西瓜视频",
+			3:  "优酷",
+			4:  "Airtable",
+			5:  "百度地图",
+			6:  "高德地图",
+			7:  "TikTok",
+			8:  "Figma",
+			9:  "墨刀",
+			10: "Canva",
+			11: "CodePen",
+			12: "飞书问卷",
+			13: "金数据",
+			14: "谷歌地图",
+			15: "YouTube",
+			99: "其他",
+		}
+
+		typeName := "未知类型"
+		if name, ok := typeNames[int(iframe.Component.IframeType)]; ok {
+			typeName = name
+		}
+
+		buf.WriteString(fmt.Sprintf("> 类型: %s\n", typeName))
+
+		// 显示 URL（如果有的话）
+		if iframe.Component.URL != "" {
+			buf.WriteString(">\n")
+			buf.WriteString(fmt.Sprintf("> 链接: %s\n", iframe.Component.URL))
+		}
+	}
+
+	buf.WriteString(">\n")
+	buf.WriteString("> *注：嵌入内容无法直接在 Markdown 中显示，请访问飞书查看原始内容*\n")
+	buf.WriteString("\n\n")
 
 	return buf.String()
 }

--- a/core/parser_test.go
+++ b/core/parser_test.go
@@ -39,7 +39,7 @@ func TestParseDocxContent(t *testing.T) {
 			byteValue, _ := io.ReadAll(jsonFile)
 			json.Unmarshal(byteValue, &data)
 
-			parser := core.NewParser(core.NewConfig("", "").Output)
+			parser := core.NewParser(core.NewConfig("", "").Output, nil)
 			mdParsed := parser.ParseDocxContent(data.Document, data.Blocks)
 			fmt.Println(mdParsed)
 			mdParsed = engine.FormatStr("md", mdParsed)

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.21
 
 require (
 	github.com/88250/lute v1.7.3
-	github.com/chyroc/lark v0.0.98-0.20220914014759-f9ad5a16e595
+	github.com/chyroc/lark v0.0.113
 	github.com/joho/godotenv v1.4.0
 	github.com/olekukonko/tablewriter v0.0.5
 	github.com/urfave/cli/v2 v2.6.0
@@ -13,7 +13,7 @@ require (
 require (
 	github.com/gin-gonic/gin v1.9.0
 	github.com/pkg/errors v0.9.1
-	github.com/stretchr/testify v1.8.1
+	github.com/stretchr/testify v1.8.2
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -49,6 +49,8 @@ github.com/chyroc/lark v0.0.97-0.20220706015537-dc21f96c8ebd h1:i7uP6BA2aHqLSqn3
 github.com/chyroc/lark v0.0.97-0.20220706015537-dc21f96c8ebd/go.mod h1:ZMmVyuBFmzLkiVKuORy7nEoNK/WvDh77cMsc3laJ5H8=
 github.com/chyroc/lark v0.0.98-0.20220914014759-f9ad5a16e595 h1:fonLvnX4ULSjn5E+rk0OevXRayuuTMi0kTjMSBeBenE=
 github.com/chyroc/lark v0.0.98-0.20220914014759-f9ad5a16e595/go.mod h1:ZMmVyuBFmzLkiVKuORy7nEoNK/WvDh77cMsc3laJ5H8=
+github.com/chyroc/lark v0.0.113 h1:sIW5lTCzx8DUietWfX0XTuh6BgosVT34n5HUED9pk38=
+github.com/chyroc/lark v0.0.113/go.mod h1:YnIIdBcxsAI1jbpAg+A+jF8qfo+yENPdr3I6+XpeGao=
 github.com/chyroc/lark_rate_limiter v0.1.0 h1:nZA4Ipx3jqqg1PXRxv2dTYLEyz0h0GY8yhUo9Az15j8=
 github.com/chyroc/lark_rate_limiter v0.1.0/go.mod h1:N7R/j7o8yKRyBiP/AtUHAWNRlxMECsGV5w7NMw9vKuA=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
@@ -261,6 +263,8 @@ github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKsk=
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
+github.com/stretchr/testify v1.8.2 h1:+h33VjcLVPDHtOdpUCuF+7gSuG3yGIftsP1YvFihtJ8=
+github.com/stretchr/testify v1.8.2/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/twitchyliquid64/golang-asm v0.15.1 h1:SU5vSMR7hnwNxj24w34ZyCi/FmDZTkS4MhqMhdFk5YI=

--- a/utils/url.go
+++ b/utils/url.go
@@ -36,13 +36,23 @@ func ValidateFolderURL(url string) (string, error) {
 }
 
 func ValidateWikiURL(url string) (string, string, error) {
-	// reg := regexp.MustCompile("^https://[\\w-.]+/wiki/settings/([a-zA-Z0-9]+)")
+	// Try to match /wiki/settings/[space_id] format first
 	reg := regexp.MustCompile(`^(https://[\w-.]+)/wiki/settings/([a-zA-Z0-9]+)$`)
 	matchResult := reg.FindStringSubmatch(url)
-	if matchResult == nil || len(matchResult) != 3 {
-		return "", "", errors.Errorf("Invalid feishu/larksuite folder URL pattern")
+	if matchResult != nil && len(matchResult) == 3 {
+		prefixURL := matchResult[1]
+		wikiToken := matchResult[2]
+		return prefixURL, wikiToken, nil
 	}
-	prefixURL := matchResult[1]
-	wikiToken := matchResult[2]
-	return prefixURL, wikiToken, nil
+	
+	// Try to match /wiki/[node_token] format
+	reg = regexp.MustCompile(`^(https://[\w-.]+)/wiki/([a-zA-Z0-9]+)$`)
+	matchResult = reg.FindStringSubmatch(url)
+	if matchResult != nil && len(matchResult) == 3 {
+		prefixURL := matchResult[1]
+		wikiToken := matchResult[2]
+		return prefixURL, wikiToken, nil
+	}
+	
+	return "", "", errors.Errorf("Invalid feishu/larksuite folder URL pattern")
 }

--- a/utils/url.go
+++ b/utils/url.go
@@ -44,7 +44,7 @@ func ValidateWikiURL(url string) (string, string, error) {
 		wikiToken := matchResult[2]
 		return prefixURL, wikiToken, nil
 	}
-	
+
 	// Try to match /wiki/[node_token] format
 	reg = regexp.MustCompile(`^(https://[\w-.]+)/wiki/([a-zA-Z0-9]+)$`)
 	matchResult = reg.FindStringSubmatch(url)
@@ -53,6 +53,6 @@ func ValidateWikiURL(url string) (string, string, error) {
 		wikiToken := matchResult[2]
 		return prefixURL, wikiToken, nil
 	}
-	
+
 	return "", "", errors.Errorf("Invalid feishu/larksuite folder URL pattern")
 }

--- a/web/download.go
+++ b/web/download.go
@@ -40,7 +40,7 @@ func downloadHandler(c *gin.Context) {
 	)
 
 	// Process the download
-	parser := core.NewParser(config.Output)
+	parser := core.NewParser(config.Output, client)
 	markdown := ""
 
 	// for a wiki page, we need to renew docType and docToken first


### PR DESCRIPTION
This PR adds support for embedded spreadsheets (block_type 30) in Feishu documents and fixes quote block formatting issues.

**Changes:**
- Add ParseDocxBlockSheet to handle spreadsheet blocks
- Add GetSheetContent to fetch spreadsheet data via Feishu API
- Fix quote block line breaking with two trailing spaces
- Update Parser to include Client field for API calls

**Testing:**
Tested with Feishu wiki documents containing embedded spreadsheets and quote blocks.